### PR TITLE
Add outputSchema support for tool response type documentation

### DIFF
--- a/Lib.GAB/Server/GabpServer.cs
+++ b/Lib.GAB/Server/GabpServer.cs
@@ -260,10 +260,46 @@ namespace Lib.GAB.Server
                     required = p.Required,
                     defaultValue = p.DefaultValue
                 }).ToList(),
+                outputSchema = t.ResponseFields.Count > 0 ? BuildOutputSchema(t.ResponseFields) : null,
                 requiresAuth = t.RequiresAuth
             }).ToList();
 
             await SendResponseAsync(connection, request.Id, new { tools });
+        }
+
+        private static Dictionary<string, object> BuildOutputSchema(List<ToolResponseFieldInfo> fields)
+        {
+            var properties = new Dictionary<string, object>();
+            var required = new List<string>();
+
+            foreach (var f in fields)
+            {
+                var prop = new Dictionary<string, object>();
+
+                if (f.Nullable)
+                    prop["type"] = new[] { f.Type, "null" };
+                else
+                    prop["type"] = f.Type;
+
+                if (!string.IsNullOrEmpty(f.Description))
+                    prop["description"] = f.Description;
+
+                properties[f.Name] = prop;
+
+                if (f.Always)
+                    required.Add(f.Name);
+            }
+
+            var schema = new Dictionary<string, object>
+            {
+                ["type"] = "object",
+                ["properties"] = properties
+            };
+
+            if (required.Count > 0)
+                schema["required"] = required;
+
+            return schema;
         }
 
         private async Task HandleToolsCallAsync(IConnection connection, GabpRequest request)
@@ -297,7 +333,9 @@ namespace Lib.GAB.Server
                 }
 
                 object arguments = null;
-                callParams.TryGetValue("arguments", out arguments);
+                // Try "parameters" first (GABS sends this), fall back to "arguments" for compatibility
+                if (!callParams.TryGetValue("parameters", out arguments))
+                    callParams.TryGetValue("arguments", out arguments);
                 var result = await _toolRegistry.CallToolAsync(toolName, arguments);
                 
                 await SendResponseAsync(connection, request.Id, result);

--- a/Lib.GAB/Tools/IToolRegistry.cs
+++ b/Lib.GAB/Tools/IToolRegistry.cs
@@ -26,9 +26,45 @@ namespace Lib.GAB.Tools
         public List<ToolParameterInfo> Parameters { get; set; } = new List<ToolParameterInfo>();
 
         /// <summary>
+        /// Response field documentation
+        /// </summary>
+        public List<ToolResponseFieldInfo> ResponseFields { get; set; } = new List<ToolResponseFieldInfo>();
+
+        /// <summary>
         /// Whether authentication is required
         /// </summary>
         public bool RequiresAuth { get; set; } = true;
+    }
+
+    /// <summary>
+    /// Information about a field in the tool response
+    /// </summary>
+    public class ToolResponseFieldInfo
+    {
+        /// <summary>
+        /// Field name in the JSON response
+        /// </summary>
+        public string Name { get; set; } = string.Empty;
+
+        /// <summary>
+        /// JSON Schema type (string, boolean, integer, number, object, array)
+        /// </summary>
+        public string Type { get; set; } = "string";
+
+        /// <summary>
+        /// Human-readable description
+        /// </summary>
+        public string Description { get; set; }
+
+        /// <summary>
+        /// Whether this field is always present
+        /// </summary>
+        public bool Always { get; set; } = true;
+
+        /// <summary>
+        /// Whether this field can be null
+        /// </summary>
+        public bool Nullable { get; set; } = false;
     }
 
     /// <summary>

--- a/Lib.GAB/Tools/ToolAttribute.cs
+++ b/Lib.GAB/Tools/ToolAttribute.cs
@@ -53,4 +53,45 @@ namespace Lib.GAB.Tools
         /// </summary>
         public object DefaultValue { get; set; }
     }
+
+    /// <summary>
+    /// Attribute to document a field in the tool's response object.
+    /// Apply multiple times to a method to document each response field.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    public class ToolResponseAttribute : Attribute
+    {
+        /// <summary>
+        /// Field name in the JSON response (e.g. "success", "screenType")
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// JSON Schema type: "boolean", "string", "integer", "number", "object", "array"
+        /// </summary>
+        public string Type { get; set; } = "string";
+
+        /// <summary>
+        /// Human-readable description of this field
+        /// </summary>
+        public string Description { get; set; }
+
+        /// <summary>
+        /// Whether this field is always present in the response (default true)
+        /// </summary>
+        public bool Always { get; set; } = true;
+
+        /// <summary>
+        /// Whether this field can be null
+        /// </summary>
+        public bool Nullable { get; set; } = false;
+
+        public ToolResponseAttribute(string name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+                throw new ArgumentException("Response field name cannot be null or empty", nameof(name));
+
+            Name = name;
+        }
+    }
 }

--- a/Lib.GAB/Tools/ToolRegistry.cs
+++ b/Lib.GAB/Tools/ToolRegistry.cs
@@ -77,7 +77,8 @@ namespace Lib.GAB.Tools
                     Name = toolAttr.Name,
                     Description = toolAttr.Description,
                     RequiresAuth = toolAttr.RequiresAuth,
-                    Parameters = GetParameterInfo(method)
+                    Parameters = GetParameterInfo(method),
+                    ResponseFields = GetResponseFieldInfo(method)
                 };
 
                 RegisterTool(toolAttr.Name, CreateHandler(method, instance), toolInfo);
@@ -103,6 +104,23 @@ namespace Lib.GAB.Tools
             }
             
             return parameters;
+        }
+
+        private List<ToolResponseFieldInfo> GetResponseFieldInfo(MethodInfo method)
+        {
+            var fields = new List<ToolResponseFieldInfo>();
+            foreach (var attr in method.GetCustomAttributes<ToolResponseAttribute>())
+            {
+                fields.Add(new ToolResponseFieldInfo
+                {
+                    Name = attr.Name,
+                    Type = attr.Type,
+                    Description = attr.Description,
+                    Always = attr.Always,
+                    Nullable = attr.Nullable
+                });
+            }
+            return fields;
         }
 
         private Func<object, Task<object>> CreateHandler(MethodInfo method, object instance)


### PR DESCRIPTION
## Summary

Adds the ability for GABP tools to declare their response schema, so MCP clients can see the return types of each tool.

- **`ToolResponseAttribute`**: New attribute applied to tool methods to document each field in the JSON response. Supports name, JSON Schema type, description, always-present, and nullable flags. Multiple attributes per method for multi-field responses.

- **`ToolResponseFieldInfo` + `ToolInfo.ResponseFields`**: Data model for carrying response field metadata through the tool registry alongside existing parameter info.

- **`BuildOutputSchema` in GabpServer**: Converts `ToolResponseFieldInfo` into a JSON Schema object and sends it as `outputSchema` in the `tools/list` GABP response. Only included when the tool has response field annotations.

- **Parameters/arguments fallback**: `tools/call` now tries the `"parameters"` key first (sent by GABS), falling back to `"arguments"` for compatibility with other clients.

## Wire format

Tools with response annotations now include `outputSchema` in `tools/list`:

```json
{
  "name": "core/ping",
  "outputSchema": {
    "type": "object",
    "properties": {
      "message": { "type": "string", "description": "Always 'pong'" },
      "timestamp": { "type": "string", "description": "Server UTC timestamp" }
    },
    "required": ["message", "timestamp"]
  }
}